### PR TITLE
Bump golangci lint

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,5 +2,5 @@ experimental_monorepo_root = true
 
 [tools]
 go = "latest"
-golangci-lint = "2.7.1" # Freeze since I'm not actively developing go
+golangci-lint = "2.7.2"
 rust = { version = "stable", profile = "default" }

--- a/mise.toml
+++ b/mise.toml
@@ -2,5 +2,5 @@ experimental_monorepo_root = true
 
 [tools]
 go = "latest"
-golangci-lint = "2.7.2"
+golangci-lint = "2"
 rust = { version = "stable", profile = "default" }


### PR DESCRIPTION
Pin golangci-lint at a major version instead of exact, results in bumping the patch